### PR TITLE
Settings pane now disables placement of shapes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,7 +81,7 @@ function App() {
                                         settingState={settingState}
                                         colorChangeHandler={colorChangeHandler}/> }
 
-        { draw && <Draw colorSettings={canvasColorSettings} settingStateChangeHandler={settingStateChangeHandler}/> }
+        { draw && <Draw colorSettings={canvasColorSettings} settingStateChangeHandler={settingStateChangeHandler} settingState={settingState}/> }
         </>
     );
 }

--- a/src/Components/Canvas/Canvas.tsx
+++ b/src/Components/Canvas/Canvas.tsx
@@ -72,19 +72,25 @@ function sketch (p) {
             setClearCanvasInParent();
         }
 
-        else if (settingState===0){
-            p.mouseClicked = function (event) {
-                // if (event.type == 'touchstart') {
-                    return Animation.mousePressed(sketchData, p);
+        p.mouseClicked = function (event) {
+            // if (event.type == 'touchstart') {
+            if (settingState===0){
+                return Animation.mousePressed(sketchData, p);
             }
-            
-            p.mouseReleased = function() {
+        }
+        
+        
+        p.mouseReleased = function() {
+            if (settingState===0){
                 Animation.mouseReleased(sketchData, p);
-                // return false;
             }
+            // return false;
+        }
 
+        if (settingState===0){
             Animation.draw(sketchData, p);
         }
+        
     }
 }
 

--- a/src/Components/Canvas/Canvas.tsx
+++ b/src/Components/Canvas/Canvas.tsx
@@ -72,20 +72,19 @@ function sketch (p) {
             setClearCanvasInParent();
         }
 
-        p.mouseClicked = function (event) {
-            // if (event.type == 'touchstart') {
-            if (settingState===0){ //0=settings closed
-                return Animation.mousePressed(sketchData, p);
+        else if (settingState===0){
+            p.mouseClicked = function (event) {
+                // if (event.type == 'touchstart') {
+                    return Animation.mousePressed(sketchData, p);
             }
-        }
-        
-        p.mouseReleased = function() {
-            Animation.mouseReleased(sketchData, p);
-            // return false;
-        }
-        // if (settingState===0) {
+            
+            p.mouseReleased = function() {
+                Animation.mouseReleased(sketchData, p);
+                // return false;
+            }
+
             Animation.draw(sketchData, p);
-        // }
+        }
     }
 }
 

--- a/src/Components/Canvas/Canvas.tsx
+++ b/src/Components/Canvas/Canvas.tsx
@@ -31,6 +31,7 @@ function sketch (p) {
     let reset = false;
     let setClearCanvasInParent = () => {};
     let renderer;
+    let settingState;
 
     function inCanvas(mouseX, mouseY, width, height) {
         return mouseX >= 0 && mouseX <= width && mouseY >= 0 && mouseY <= height;
@@ -41,6 +42,7 @@ function sketch (p) {
         renderer.parent("canvas");
         sketchData.figs = [];
         sketchData.points = [];
+        settingState = 0;
     }
 
     p.windowResized = function () {
@@ -59,6 +61,7 @@ function sketch (p) {
         }
         reset = props.canvasSettings.reset;
         setClearCanvasInParent = props.canvasSettings.resetInParent;
+        settingState = props.canvasSettings.settingState;
     }
 
     p.draw = function () {
@@ -71,15 +74,18 @@ function sketch (p) {
 
         p.mouseClicked = function (event) {
             // if (event.type == 'touchstart') {
-            return Animation.mousePressed(sketchData, p);
+            if (settingState===0){ //0=settings closed
+                return Animation.mousePressed(sketchData, p);
+            }
         }
         
         p.mouseReleased = function() {
             Animation.mouseReleased(sketchData, p);
             // return false;
         }
-        
-        Animation.draw(sketchData, p);
+        // if (settingState===0) {
+            Animation.draw(sketchData, p);
+        // }
     }
 }
 
@@ -88,7 +94,7 @@ export default function Canvas(props) {
          <div className="canvas-container" id="canvas">
                 <P5Wrapper 
                     className="p5Wrapper"
-                    sketch={sketch}     
+                    sketch={sketch}
                     canvasSettings={props.canvasSettings}/>
         </div>
     ); 

--- a/src/Types/Figures.tsx
+++ b/src/Types/Figures.tsx
@@ -35,7 +35,8 @@ export type CanvasSettings = {
     selectedAnimation: SelectedAnimation, 
     colorSettings: ShapeColors,
     reset: Boolean,
-    resetInParent: voidFunc
+    resetInParent: voidFunc,
+    settingState: number
 };
 
 export type SketchData = {

--- a/src/Views/Draw/Draw.tsx
+++ b/src/Views/Draw/Draw.tsx
@@ -48,6 +48,7 @@ export default function Draw(props){
       colorSettings: props.colorSettings,
       reset: clearCanvas,
       resetInParent: setClearCanvasHandler,
+      settingState: props.settingState
     };
     
     // TODO: pull this out to the parent: App.tsx


### PR DESCRIPTION
Passed `settingState` through `canvasSettings`, disables `Animation.mousePressed()` when `settingState !== 0`.