### PR TITLE
Settings highlight on hover

### DIFF
--- a/src/Views/Settings/Settings.css
+++ b/src/Views/Settings/Settings.css
@@ -33,12 +33,16 @@
 
     border-right: 1px solid black;
 } .settings-side-bar .options {
-    height: 15%;
+    height: 55%;
     width: 100%;
     
     display: flex;
     justify-content: center;
     align-items: center;
+}
+
+.options:hover{
+    background-color: #ACABAB;
 }
 
 .tab-selection {


### PR DESCRIPTION
Forgot to push this last week. Changes the appearance of the red bar on the side, lmk if you think that's a priority to restore