### PR TITLE
Bubblepop animation improvements

### DIFF
--- a/src/Types/Animations/Animation.tsx
+++ b/src/Types/Animations/Animation.tsx
@@ -113,6 +113,9 @@ export class Animation {
             case SelectedAnimation.WobblySwarm:
                 WobblySwarm.mousePressed(sketchData, p);
                 break;
+            case SelectedAnimation.BubblePop:
+                BubblePop.mousePressed(sketchData, p);
+                break;
             case SelectedAnimation.None:
                 break; 
         }

--- a/src/Types/Animations/Animation.tsx
+++ b/src/Types/Animations/Animation.tsx
@@ -21,15 +21,15 @@ export function newFigure(selectedFigure, x: number, y:number, p: p5, color?:str
 
     switch(selectedFigure) {
         case SelectedShape.Circle:
-            if (!color) color = Animation.circleColors[Math.floor(Math.random() * Animation.circleColors.length)];
+            if (!color) color = Animation.getCircleColor();
             return new CircleFigure(x, y, dimension, color, p);
             
         case SelectedShape.Rectangle:
-            if (!color) color = Animation.rectColors[Math.floor(Math.random() * Animation.rectColors.length)];
+            if (!color) color = Animation.getRectColor();
             return new SquareFigure(x, y, dimension, color, p);
 
         case SelectedShape.Triangle:
-            if (!color) color = Animation.triangleColors[Math.floor(Math.random() * Animation.triangleColors.length)]
+            if (!color) color = Animation.getTriangleColor();
             return new TriangleFigure(x, y, dimension, color, p);
         default:
     }
@@ -47,6 +47,19 @@ export class Animation {
         Animation.triangleColors = generateColorSpectrum(sketchData.colorSettings.triangle);
     }
 
+    static getRectColor() : string {
+        return Animation.rectColors[Math.floor(Math.random() * Animation.rectColors.length)];
+    }
+
+    static getCircleColor() : string {
+        return Animation.circleColors[Math.floor(Math.random() * Animation.circleColors.length)];
+    }
+
+    static getTriangleColor() : string {
+        return Animation.triangleColors[Math.floor(Math.random() * Animation.triangleColors.length)]
+    }
+
+
     static redraw(sketchData: SketchData, p: p5) {
         switch(sketchData.selectedAnimation) {
             case SelectedAnimation.FillScreenWithFigures:
@@ -58,7 +71,6 @@ export class Animation {
     }
 
     static draw(sketchData: SketchData, p) {
-
         switch(sketchData.selectedAnimation) {
             case SelectedAnimation.BubblePop:
                 BubblePop.draw(sketchData, p);

--- a/src/Types/Animations/BubblePop.tsx
+++ b/src/Types/Animations/BubblePop.tsx
@@ -37,7 +37,7 @@ export class BubblePop extends Animation {
             case("CIRCLE"):
                 cache = this.circleCache;
                 shape = SelectedShape.Circle;
-                // color = Animation.getCircleColor();
+                // color = getCircleColor();
                 break;
             case("RECT"):
                 xpos += dim/2;
@@ -45,12 +45,12 @@ export class BubblePop extends Animation {
 
                 cache = this.squareCache;
                 shape = SelectedShape.Rectangle;
-                // color = this.getRectColor();
+                // color = getRectColor();
                 break;
             case("POLY"):
                 cache = this.triangleCache;
                 shape = SelectedShape.Triangle;
-                // color = this.getTriangleColor();
+                // color = getTriangleColor();
                 break;
         }
 
@@ -164,18 +164,6 @@ export class BubblePop extends Animation {
 
             fig.timer -= 1;
 
-            // prevent lag and sound spike
-
-            /*
-            for (let i = 0; i < nodes.length; i++) {
-                if (AnimatedFigure.collidesWith(nodes[i], fig) && nodes[i] != fig) {
-                    let directionVector = fig.pos.copy().sub(nodes[i].pos.copy()).normalize();
-                    fig.velocity.mult(p.createVector(directionVector.x,directionVector.y,0));
-                    nodes[i].velocity.mult(p.createVector(-1*directionVector.x, -1*directionVector.y, 0));
-                }
-            }
-            */
-
             if (fig.collideCanvasLeft(width, height) || fig.collideCanvasRight(width, height)) {
                 fig.velocity.x *= -1;
             }
@@ -199,15 +187,18 @@ export class BubblePop extends Animation {
             this.counter++;
         });
 
-        if(to_burst.length > 0) console.log("to burst length: " + to_burst.length);
+        if(to_burst.length > 0)
         for (let i = 0; i < to_burst.length; i++) {
             this.burst_cache(to_burst[i], sketchData,  p)
         }
     }
 
     static mousePressed(sketchData: SketchData, p) {
-        if(sketchData.figs.length >= this.NUM_FIGURES) {
-            this.burst(sketchData.figs[0], sketchData, p);
+        if (AnimatedFigure.mouseOnCanvas(p, sketchData.canvasWidth, sketchData.canvasHeight))
+        {
+            if(sketchData.figs.length >= this.NUM_FIGURES) {
+                this.burst_cache(sketchData.figs[0], sketchData, p);
+            }
         }
         return false;
     }

--- a/src/Types/Animations/BubblePop.tsx
+++ b/src/Types/Animations/BubblePop.tsx
@@ -1,20 +1,153 @@
-import { SketchData } from '../Figures';
+import { SelectedShape, SketchData } from '../Figures';
 import P5 from 'p5';
 import { AnimatedFigure } from '../ProcessingFigures';
 import 'p5collide';
-import { findDOMNode } from 'react-dom';
+import { newFigure } from './Animation';
 
 export class BubblePop extends Animation {
 
-    static burst(fig, sketchData) {
+    static NUM_FIGURES = 200;
+    static CACHE_LIMIT = 100;
+    static counter = 0;
 
-        if (fig.timer <= 25) {
-            let index = sketchData.figs.indexOf(fig);
-            sketchData.figs.splice(index, 1);
-            fig.pop.play();
+    static colorSettingsCache;
+    static circleCache = [];
+    static squareCache = [];
+    static triangleCache = [];
+
+    static burst_cache(fig, sketchData, p) {
+
+        let index = sketchData.figs.indexOf(fig);
+
+        let type : string = fig.getShapeDescriptor().type;
+        let dim : number = fig.dim;
+        let xpos : number = fig.pos.x;
+        let ypos : number = fig.pos.y;
+
+        for(let i=0; i < 3; ++i){
+            fig.dim += 5;
+            fig.display();
         }
+        
+        var shape : SelectedShape;
+        var cache;
+        // var color;
+        
+        switch(type) {
+            case("CIRCLE"):
+                cache = this.circleCache;
+                shape = SelectedShape.Circle;
+                // color = Animation.getCircleColor();
+                break;
+            case("RECT"):
+                xpos += dim/2;
+                ypos += dim/2;
+
+                cache = this.squareCache;
+                shape = SelectedShape.Rectangle;
+                // color = this.getRectColor();
+                break;
+            case("POLY"):
+                cache = this.triangleCache;
+                shape = SelectedShape.Triangle;
+                // color = this.getTriangleColor();
+                break;
+        }
+
+        if(dim > 25) { 
+            if(shape && sketchData.figs.length + 5 <= this.NUM_FIGURES) {
+                let newFig : AnimatedFigure;
+                let numNewFigs = dim/10 > 5 ? 5 : Math.floor(dim/10);
+                numNewFigs = Math.min(numNewFigs, cache.length);
+                for(let i = 0; i < numNewFigs; ++i) {
+                    newFig = cache.shift();
+                    newFig.pos.x = xpos + ((Math.random() - 0.5) * 2)*dim/2;
+                    newFig.pos.y = ypos + ((Math.random() - 0.5) * 2)*dim/2;
+                    newFig.dim = dim * (0.3 + Math.random() * 0.3);
+
+                    sketchData.figs.push(newFig);
+                }
+            }
+        }
+        let recycleFig = sketchData.figs.splice(index, 1)[0]
+        // recycleFig.color = 
+        cache.push(recycleFig);
+        fig.pop.play();
+    }
+    
+    static burst(fig, sketchData, p) {
+        let index = sketchData.figs.indexOf(fig);
+
+        let type : string = fig.getShapeDescriptor().type;
+        let dim : number = fig.dim;
+        let xpos : number = fig.pos.x;
+        let ypos : number = fig.pos.y;
+
+        for(let i=0; i < 3; ++i){
+            fig.dim += 5;
+            fig.display();
+        }
+
+        if(dim > 25) {
+            let shape : SelectedShape;
+
+            switch(type) {
+                case("CIRCLE"):
+                    shape = SelectedShape.Circle;
+                    break;
+                case("RECT"):
+                    xpos += dim/2;
+                    ypos += dim/2;
+                    shape = SelectedShape.Rectangle;
+                    break;
+                case("POLY"):
+                    shape = SelectedShape.Triangle;
+                    break;
+            }
+            
+            if(shape && sketchData.figs.length + 5 <= this.NUM_FIGURES) {
+                let newFig : AnimatedFigure;
+                let numNewFigs = dim/10 > 5 ? 5 : Math.floor(dim/10);
+                for(let i = 0; i < numNewFigs; ++i) {
+                    let xOffset = ((Math.random() - 0.5) * 2)*dim/2;
+                    let yOffset = ((Math.random() - 0.5) * 2)*dim/2;
+                    newFig = newFigure(shape, xpos + xOffset, ypos + yOffset, p);
+                    newFig.dim = dim * (0.3 + Math.random() * 0.3);
+                    sketchData.figs.push(newFig);
+                }
+            }
+        }
+        sketchData.figs.splice(index, 1);
+        fig.pop.play();
     }
 
+    static cacheFigures(sketchData, p) {
+        if(!this.colorSettingsCache) this.colorSettingsCache = sketchData.colorSettings;
+        else {
+            if(this.colorSettingsCache.triangle != sketchData.colorSettings.triangle) this.triangleCache = [];
+            if(this.colorSettingsCache.rectangle != sketchData.colorSettings.rectangle) this.squareCache = [];
+            if(this.colorSettingsCache.circle != sketchData.colorSettings.circle) this.circleCache = [];
+            this.colorSettingsCache = sketchData.colorSettings;
+        }
+
+        switch(this.counter % 5) {
+            case(0): 
+                if(this.triangleCache.length < this.CACHE_LIMIT) {
+                    this.triangleCache.push(newFigure(SelectedShape.Triangle, 0, 0, p));
+                }
+                break;
+            case(2):
+                if(this.squareCache.length < this.CACHE_LIMIT) {
+                    this.squareCache.push(newFigure(SelectedShape.Rectangle, 0, 0, p));
+                }
+                break;
+            case(4):
+                if(this.circleCache.length < this.CACHE_LIMIT) {
+                    this.circleCache.push(newFigure(SelectedShape.Circle, 0, 0, p));
+                }
+                break;
+        }
+    }
     static draw(sketchData: SketchData, p) {
         p.background(sketchData.colorSettings.background);
         
@@ -22,7 +155,8 @@ export class BubblePop extends Animation {
         let rotFactor = 0.1
 
         let to_burst = []
-        let nodes = sketchData.figs;
+
+        this.cacheFigures(sketchData, p);
 
         sketchData.figs.forEach(fig => {
             let width = sketchData.canvasWidth;
@@ -31,48 +165,30 @@ export class BubblePop extends Animation {
             fig.timer -= 1;
 
             // prevent lag and sound spike
-            if (fig.dead){
 
-                fig.dead = false;
-                fig.timer = 60;
-                fig.velocity.y = -5;
-            }
-
+            /*
             for (let i = 0; i < nodes.length; i++) {
                 if (AnimatedFigure.collidesWith(nodes[i], fig) && nodes[i] != fig) {
-                    if (!to_burst.includes(nodes[i])){
-                            to_burst.push(nodes[i])
-                    }
-                    if (!to_burst.includes(fig)){
-                            to_burst.push(fig)
-                    }
+                    let directionVector = fig.pos.copy().sub(nodes[i].pos.copy()).normalize();
+                    fig.velocity.mult(p.createVector(directionVector.x,directionVector.y,0));
+                    nodes[i].velocity.mult(p.createVector(-1*directionVector.x, -1*directionVector.y, 0));
                 }
             }
+            */
 
             if (fig.collideCanvasLeft(width, height) || fig.collideCanvasRight(width, height)) {
-                
-                if (!to_burst.includes(fig)){
-                    to_burst.push(fig)
-                }
-                //fig.velocity.x *= -1;
+                fig.velocity.x *= -1;
             }
         
             if (fig.collideCanvasTop(width, height) || fig.collideCanvasBottom(width, height)) {
-                if (!to_burst.includes(fig)){
-                    to_burst.push(fig)
-                }
-                //fig.velocity.y *= -1;
+                fig.velocity.y *= -1;
             }
             
             if (fig.collideWithMouse()) {
-
-                if (!to_burst.includes(fig)){
+                if (!to_burst.includes(fig) && fig.timer < 0){
                     to_burst.push(fig)
                 }
-                //let speed = fig.velocity.mag();
-                //let repelForce = fig.pos.copy().sub(p.createVector(p.mouseX, p. mouseY)).normalize();
-                //fig.velocity.add(repelForce.mult(speed));
-            }
+            } 
 
             fig.rotAngle = fig.randSign()*rotFactor;
             fig.velocity.rotate(fig.rotAngle);
@@ -80,19 +196,23 @@ export class BubblePop extends Animation {
         
             fig.pos.add(translation);
             fig.display();
+            this.counter++;
         });
 
+        if(to_burst.length > 0) console.log("to burst length: " + to_burst.length);
         for (let i = 0; i < to_burst.length; i++) {
-
-            this.burst(to_burst[i], sketchData)
+            this.burst_cache(to_burst[i], sketchData,  p)
         }
     }
 
     static mousePressed(sketchData: SketchData, p) {
+        if(sketchData.figs.length >= this.NUM_FIGURES) {
+            this.burst(sketchData.figs[0], sketchData, p);
+        }
         return false;
     }
 
     static mouseReleased(sketchData: SketchData, p) {
-
+        return false;
     }
 }

--- a/src/Types/ProcessingFigures.tsx
+++ b/src/Types/ProcessingFigures.tsx
@@ -1,5 +1,3 @@
-import 'p5';
-import p5 from 'p5';
 import P5 from 'p5';
 // import { collapseTextChangeRangesAcrossMultipleVersions } from 'typescript';
 //import useSound from 'use-sound';
@@ -8,7 +6,7 @@ import bounceSFX from '../Sounds/bounce.mp3';
 import popSFX from '../Sounds/pop.mp3';
 import thudSFX from '../Sounds/thud.mp3';
 import * as Collides from 'p5collide';
-import { SketchData, CustomFigureStyles } from './Figures';
+import { CustomFigureStyles } from './Figures';
 import './Animations/ColorSampling';
 
 const MAX_SPEED = 15;


### PR DESCRIPTION
When you mouse over figures they increase in size until they burst into multiple smaller figures. 

Creating multiple figures each draw loop was causing the animation to lag too much so up to 100 figures of each type are cached in an array. When figures are popped they are recycled and added back into the cache. This greatly improves the performance, but it still lags if the screen is filled with shapes and many of them are popped at once. 

There is also a small bug if the figure color is changed and then a figure with the previous color is popped. This figure will be recycled back into the cache with the old color. This can be fixed if Bubblepop can access the getRectColor(), getCircleColor() getTriangleColor() functions in the base Animation class, but for some reason it wasn't working. There may be a problem with polymorphism or i am jus big dum.  