### PR TITLE
Fixed settings css animation fps drop

### DIFF
--- a/src/Views/Settings/Settings.css
+++ b/src/Views/Settings/Settings.css
@@ -12,11 +12,11 @@
 }
 
 .settings-container.opening {
-    animation: slideUp .2s linear;
+    animation: slideUp 200ms ease-in;
 }
 
 .settings-container.closing{
-    animation: slideDown .2s linear;
+    animation: slideDown 200ms ease-out;
 }
 
 .settings-side-bar {

--- a/src/Views/Settings/Settings.tsx
+++ b/src/Views/Settings/Settings.tsx
@@ -26,9 +26,16 @@ export default function Settings(props) {
         setTabSelection(newTabSelection)
     }
 
+    function onAnimationEnd(event) {
+        if(event.target.className.includes("opening")) 
+            setTimeout(props.settingStateChangeHandler, 20);    
+        else 
+            props.settingStateChangeHandler();
+    }
+
     return (
         <div className={"settings-container " + (settingStates[props.settingState]) }
-             onAnimationEnd={() => props.settingStateChangeHandler()} >
+             onAnimationEnd={onAnimationEnd} >
 
             <div className="settings-side-bar">
                 <div className={"options " + colorSchemeUnderline} 


### PR DESCRIPTION
Kind of a hacky solution, but it fixed the major fps drop issue. 

For some reason when opening the settings page  `onAnimationEnd` was being triggered before the animation frames had finished rendering. The fix just adds a delay to `props.settingStateChangeHandler();` so that the animation has time to finish up before the sudden spike in activity. 
